### PR TITLE
Typo correction in example: previously lower case U :  #' uI <- bitly_userInfo()

### DIFF
--- a/R/bitly_information.R
+++ b/R/bitly_information.R
@@ -43,7 +43,7 @@
 #' @examples 
 #' \dontrun{ 
 #' bitly_token <- bitly_auth(key = "be03aead58f23bc1aee6e1d7b7a1d99d62f0ede8", secret = "")
-#' uI <- bitly_userInfo() 
+#' uI <- bitly_UserInfo() 
 #' }
 #' 
 #' @import stringr


### PR DESCRIPTION
Corrected typo in example, capitalizing "U" in #' uI <- bitly_UserInfo()