### PR TITLE
Add ability to read stored tokens and to work non-interactively

### DIFF
--- a/R/ApiKey.R
+++ b/R/ApiKey.R
@@ -67,7 +67,7 @@ is_token <- function(x) inherits(x, "Token")
 bitly_auth <- function(key = "be03aead58f23bc1aee6e1d7b7a1d99d62f0ede8",
                       secret = "f9c6a3b18968e991e35f466e90c7d883cc176073", debug = F, token) {
   if (!missing(token)) {
-    if (is_token(token)) {
+    if (!is_token(token)) {
       token <- readRDS(token)
       if (!is_token(token)) stop("Invalid token")
     }


### PR DESCRIPTION
- Add is_token, checks for class `Token`
- `bitly_auth`:
   - add token argument
   - accepts a token or a path to an rds containing a token
   - Add stops for invalid input and non-interactive use without token
   - bitly_auth now also binds the access_token to .urlshortenerEnv (used by bitly_auth_access)
- `bitly_auth_access`: 
   - now checks for an active token before attempting re-auth