### PR TITLE
Allow bitly_retrieve_groups to retrieve the "general" group list

### DIFF
--- a/R/bitly_groups.R
+++ b/R/bitly_groups.R
@@ -295,12 +295,8 @@ bitly_retrieve_group_shorten_counts <- function(group_id = NA, showRequestURL = 
 #' rg <- bitly_retrieve_groups("") # will still work ok
 #' }
 #' @export
-bitly_retrieve_groups <- function(organization_id = NA, showRequestURL = F) {
+bitly_retrieve_groups <- function(organization_id = NULL, showRequestURL = F) {
   groups_url <- "https://api-ssl.bitly.com/v4/groups/"
-  
-  if (!is.string(organization_id)) {
-    stop("organization_id must not be empty string, NA or NULL")
-  }
   
   query <- list(access_token = bitly_auth_access(), organization_guid = organization_id)
   


### PR DESCRIPTION
`bitly_retrieve_groups` had a `stop` check on `organization_id` that prevented the function from being able to pull the "general" list of groups (not by organization)
 - Make default for `organization_id` = NULL which is ignored in request and pulls general group list
 - If `organization_id` is present it will pull the groups within the organization as expected